### PR TITLE
Fix For In Call Audio.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -449,7 +449,6 @@
   <project path="packages/screensavers/WebView" name="LineageOS/android_packages_screensavers_WebView" groups="pdk-fs" />
   <project path="packages/services/Car" name="LineageOS/android_packages_services_Car" groups="adp8064,pdk-cw-fs,pdk-fs" />
   <project path="packages/services/Mms" name="LineageOS/android_packages_services_Mms" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/services/Telecomm" name="LineageOS/android_packages_services_Telecomm" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/services/Telephony" name="LineageOS/android_packages_services_Telephony" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/wallpapers/LivePicker" name="LineageOS/android_packages_wallpapers_LivePicker" groups="pdk-fs" />
   <project path="pdk" name="platform/pdk" groups="pdk" remote="aosp" />
@@ -527,7 +526,9 @@
   <project path="tools/swt" name="platform/tools/swt" groups="notdefault,tools" remote="aosp" />
   <project path="tools/test/connectivity" name="platform/tools/test/connectivity" remote="aosp" />
   <project path="tools/tradefederation" name="platform/tools/tradefederation" groups="notdefault,tradefed" remote="aosp" />
-
+  <remove-project name="LineageOS/android_packages_services_Telecomm" />
+  <project path="packages/services/Telecomm" name="HassanSardar/android_packages_services_Telecomm-LOS" remote="github" revision="cm-14.1" />
+  
   <include name="snippets/cm.xml" />
 
 </manifest>


### PR DESCRIPTION
*Use My Telecomm Package. With This Incall Audio Works Good In Both Sims.
Don't Need To Go Back To 7.1.1
My Telecomm works with all 7.1.2 Android versions too. With Both In Call Audio Working Fine.
No Need For Patch anymore if you use my Telecomm, patch already merged.
Here it is:
https://github.com/HassanSardar/android_packages_services_Telecomm-LOS